### PR TITLE
Feature/exposing language override

### DIFF
--- a/NStackSDK/NStackSDK/Classes/NStack Manager/LocalizationWrapper.swift
+++ b/NStackSDK/NStackSDK/Classes/NStack Manager/LocalizationWrapper.swift
@@ -55,6 +55,10 @@ extension LocalizationWrapper: LocalizationWrappable {
         return translationsManager?.bestFitLanguage
     }
     
+    public var languageOverride: Language? {
+        get { return translationsManager?.languageOverride }
+        set { translationsManager?.languageOverride = newValue }
+    }
     
     public func handleLocalizationModels(localizations: [LocalizationModel], acceptHeaderUsed: String?, completion: ((Error?) -> Void)? = nil) {
         translationsManager?.handleLocalizationModels(localizations: localizations, acceptHeaderUsed: acceptHeaderUsed, completion: completion)

--- a/NStackSDK/NStackSDK/Classes/NStack Manager/LocalizationWrapper.swift
+++ b/NStackSDK/NStackSDK/Classes/NStack Manager/LocalizationWrapper.swift
@@ -24,6 +24,7 @@ public protocol NStackLocalizable where Self: UIView {
 
 public protocol LocalizationWrappable {
     var bestFitLanguage: Language? { get }
+    var languageOverride: Language? { get set }
     func translations<L: LocalizableModel>() throws -> L?
     func handleLocalizationModels(localizations: [LocalizationModel], acceptHeaderUsed: String?, completion: ((Error?) -> Void)?)
     func updateTranslations(_ completion: ((Error?) -> Void)?)


### PR DESCRIPTION
Exposed the `languageOverride` of the TranslationManager through the NStack SDK.
This is needed when the app wants to select the language. Apps like the Coloplast Clinical Trial app need this to work properly.