### PR TITLE
Refresh Translations

### DIFF
--- a/NStackSDK/NStackSDK/Classes/NStack Manager/LocalizationWrapper.swift
+++ b/NStackSDK/NStackSDK/Classes/NStack Manager/LocalizationWrapper.swift
@@ -49,6 +49,7 @@ public protocol LocalizationWrappable {
     func handleLocalizationModels(localizations: [LocalizationModel], acceptHeaderUsed: String?, completion: ((Error?) -> Void)?)
     func updateTranslations(_ completion: ((Error?) -> Void)?)
     func updateTranslations()
+    func refreshTranslations()
 
     func localize(component: NStackLocalizable, for identifier: TranslationIdentifier)
     func containsComponent(for identifier: TranslationIdentifier) -> Bool
@@ -68,6 +69,18 @@ public class LocalizationWrapper {
 }
 
 extension LocalizationWrapper: LocalizationWrappable {
+    public func refreshTranslations() {
+        for translation in originallyTranslatedComponents.keyEnumerator() {
+            if let translationIdentifier = translation as? TranslationIdentifier {
+                if let localizableComponent = originallyTranslatedComponents.object(forKey: translationIdentifier) {
+                    DispatchQueue.main.async {
+                        localizableComponent.localize(for: "\(translationIdentifier.section).\(translationIdentifier.key)")
+                    }
+                }
+            }
+        }
+    }
+
     public func translations<L: LocalizableModel>() throws -> L {
         guard let manager = translationsManager else {
             fatalError("no translations manager initialized")

--- a/NStackSDK/NStackSDK/Classes/NStack Manager/NStack.swift
+++ b/NStackSDK/NStackSDK/Classes/NStack Manager/NStack.swift
@@ -306,6 +306,7 @@ public class NStack {
 
 extension NStack: TranslatableManagerDelegate {
     public func translationManager(languageUpdated: LanguageModel?) {
-        self.languageChangedHandler?(languageUpdated?.locale)
+        print("Language Changed To: \(languageUpdated?.locale.identifier ?? "unknown")")
+        translationsManager?.refreshTranslations()
     }
 }


### PR DESCRIPTION
feature to refresh any stored translation components, this is called when the translation manager delegate language updated method is called to update all translations that have been initialised already