### PR TITLE
feat: Support custom alerts for when the app opens

### DIFF
--- a/NStackSDK/Classes/Model/AppOpenData.swift
+++ b/NStackSDK/Classes/Model/AppOpenData.swift
@@ -20,20 +20,20 @@ import NLocalizationManager
 #endif
 
 
-struct AppOpenData: Codable {
-    let count: Int?
+public struct AppOpenData: Codable {
+    public let count: Int?
 
-    let message: Message?
-    let update: Update?
-    let rateReminder: RateReminder?
+    public let message: Message?
+    public let update: Update?
+    public let rateReminder: RateReminder?
 
-    let localize: [LocalizationConfig]?
-    let platform: String
+    public let localize: [LocalizationConfig]?
+    public let platform: String
 
-    let createdAt: String
-    let lastUpdated: String?
+    public let createdAt: String
+    public let lastUpdated: String?
 
-    enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case count, message, update, localize, platform
         case lastUpdated = "last_updated"
         case createdAt = "created_at"

--- a/NStackSDK/Classes/Model/Message.swift
+++ b/NStackSDK/Classes/Model/Message.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-internal struct Message: Codable {
-    let id: Int
-    let message: String
-    let showSetting: String
-    let url: URL?
+public struct Message: Codable {
+    public let id: Int
+    public let message: String
+    public let showSetting: String
+    public let url: URL?
 
     /// Temporary solution for localizing the message's buttons
     /// - Valid keys: `okBtn`, `urlBtn`
-    let localization: [String: String]?
+    public let localization: [String: String]?
 
-    enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case id, message
         case showSetting = "show_setting"
         case url

--- a/NStackSDK/Classes/Model/RateReminder.swift
+++ b/NStackSDK/Classes/Model/RateReminder.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-struct RateReminder: Codable {
-    var title: String
-    var body: String
-    var yesButtonTitle: String
-    var laterButtonTitle: String
-    var noButtonTitle: String
-    var link: URL?
+public struct RateReminder: Codable {
+    public var title: String
+    public var body: String
+    public var yesButtonTitle: String
+    public var laterButtonTitle: String
+    public var noButtonTitle: String
+    public var link: URL?
 
-    enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case title, body, link
         case yesButtonTitle = "yesBtn"
         case laterButtonTitle = "laterBtn"

--- a/NStackSDK/Classes/Model/Update.swift
+++ b/NStackSDK/Classes/Model/Update.swift
@@ -8,48 +8,48 @@
 
 import Foundation
 
-enum UpdateState: String, Codable {
+public enum UpdateState: String, Codable {
     case disabled    = "no"
     case remind      = "yes"
     case force       = "force"
 }
 
-struct Update: Codable {
-    let newInThisVersion: Changelog?
-    let newerVersion: Version?
+public struct Update: Codable {
+    public let newInThisVersion: Changelog?
+    public let newerVersion: Version?
 
-    enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case newInThisVersion = "new_in_version"
         case newerVersion = "newer_version"
     }
 
-    struct UpdateLocalizations: Codable {
-        let title: String
-        let message: String
-        let positiveBtn: String?
-        let negativeBtn: String?
+    public struct UpdateLocalizations: Codable {
+        public let title: String
+        public let message: String
+        public let positiveBtn: String?
+        public let negativeBtn: String?
     }
 
-    struct Changelog: Codable {
-        let state: Bool
-        let lastId: Int
-        let version: String
-        let localizations: UpdateLocalizations?
+    public struct Changelog: Codable {
+        public let state: Bool
+        public let lastId: Int
+        public let version: String
+        public let localizations: UpdateLocalizations?
 
-        enum CodingKeys: String, CodingKey {
+        public enum CodingKeys: String, CodingKey {
             case state, version, localizations
             case lastId = "last_id"
         }
     }
 
-    struct Version: Codable {
-        let state: UpdateState
-        let lastId: Int
-        let version: String
-        let localizations: UpdateLocalizations
-        let link: URL?
+    public struct Version: Codable {
+        public let state: UpdateState
+        public let lastId: Int
+        public let version: String
+        public let localizations: UpdateLocalizations
+        public let link: URL?
 
-        enum CodingKeys: String, CodingKey {
+        public enum CodingKeys: String, CodingKey {
             case state, version, link
             case lastId = "last_id"
             case localizations = "translate"


### PR DESCRIPTION
I added a public callback `appOpenedAlertHandler` where the default implementation is to display native alerts (as it was before the changes). Now if the requirement is to display a custom alert/screen you can overwrite the implementation in your app.