### PR TITLE
fix: Localization updating -  dev query parameter dynamic setting

### DIFF
--- a/NStackSDK.podspec
+++ b/NStackSDK.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NStackSDK'
-  s.version          = '5.1.3'
+  s.version          = '5.2.1'
   s.summary          = 'NStackSDK is the companion software development kit to the NStack backend.'
 
 # This description is used to generate tags and improve search results.

--- a/NStackSDK/Classes/NStack Manager/ConnectionManager.swift
+++ b/NStackSDK/Classes/NStack Manager/ConnectionManager.swift
@@ -92,12 +92,22 @@ extension ConnectionManager {
 }
 // MARK: - LocalizationRepository
 extension ConnectionManager {
-    func getLocalizationDescriptors<D>(acceptLanguage: String, lastUpdated: Date?, completion: @escaping (NStackSDK.Result<[D]>) -> Void) where D: LocalizationDescriptor {
+
+    func getLocalizationDescriptors<D>(acceptLanguage: String,
+                                       lastUpdated: Date?,
+                                       completion: @escaping (NStackSDK.Result<[D]>) -> Void) where D: LocalizationDescriptor {
+        var devMode = false
+        #if DEBUG
+        devMode = true
+        #endif
+        
         let params: [String: Any] = [
             "guid": Configuration.guid,
             "platform": "ios",
             "last_updated": VersionUtilities.lastUpdatedIso8601DateString,
-            "dev": "true"
+            // NStack has a Publish feature for localizations - localization changes need to be published in order to be visible in production
+            // Setting the "dev" flag to "true" fetches the localizations changes even if they are not published
+            "dev": devMode ? "true" : "false"
         ]
 
         var headers = defaultHeaders


### PR DESCRIPTION
NStack has a Publish feature for localizations - localization changes need to be published in order to be visible in production.


Setting the `dev` flag to `true` in the `localize/resources` endpoint to the NStack API fetches the localization changes even if they are not published. 

This was hardcoded to true and triggered unnecessary requests in the production. The `dev` query parameter should be set to `true` only while developing locally. 